### PR TITLE
feature/better-enrollment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - SESSION_HASH
       - BBUSER_ID
       - BBPASSWORD
-      - MIN_ACCOUNT_AGE_DAYS
+      - AUTH_MIN_ACCOUNT_AGE_DAYS
       - MAX_IDLE_DAYS
     volumes:
       # Preserve the settings database on the host filesystem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - BBUSER_ID
       - BBPASSWORD
       - AUTH_MIN_ACCOUNT_AGE_DAYS
+      - ENROLL_MIN_ACCOUNT_AGE_DAYS
       - MAX_IDLE_DAYS
     volumes:
       # Preserve the settings database on the host filesystem

--- a/src/commands/auth/authme.ts
+++ b/src/commands/auth/authme.ts
@@ -6,7 +6,12 @@ import { stripIndents, oneLine } from 'common-tags';
 import GDNCommand from '../../helpers/GDNCommand';
 import logger, { getLogTag } from '../../helpers/logger';
 import cleanupMessages from '../../helpers/cleanupMessages';
-import { CMD_GROUPS, CMD_NAMES, API_ERROR, MIN_ACCOUNT_AGE_DAYS } from '../../helpers/constants';
+import {
+  CMD_GROUPS,
+  CMD_NAMES,
+  API_ERROR,
+  AUTH_MIN_ACCOUNT_AGE_DAYS,
+} from '../../helpers/constants';
 
 // Checks
 import isMemberBlacklisted from '../../checks/isMemberBlacklisted';
@@ -212,10 +217,11 @@ export default class AuthmeCommand extends GDNCommand {
       return member.send(reasonNoRegDate);
     }
 
-    if (age < MIN_ACCOUNT_AGE_DAYS) {
+    if (age < AUTH_MIN_ACCOUNT_AGE_DAYS) {
       logger.info(tag, 'User account age in days is below minimum, exiting');
       return member.send(oneLine`
-        Your SA account must be at least ${MIN_ACCOUNT_AGE_DAYS} days old. Please try again later.
+        Your SA account must be at least ${AUTH_MIN_ACCOUNT_AGE_DAYS} days old. Please try again
+        later.
       `);
     }
 

--- a/src/commands/public/toggleRole.ts
+++ b/src/commands/public/toggleRole.ts
@@ -17,6 +17,8 @@ interface RoleArgs {
 export default class SetDescriptionCommand extends GDNCommand {
   constructor (client: CommandoClient) {
     super(client, {
+      // Prevent others from using this for now
+      ownerOnly: true,
       name: CMD_NAMES.PUBLIC_TOGGLE_ROLE,
       group: CMD_GROUPS.PUBLIC,
       memberName: 'toggle_role',

--- a/src/helpers/auth/getSAAge.ts
+++ b/src/helpers/auth/getSAAge.ts
@@ -32,8 +32,8 @@ export default async function getSAAge (tag: LogTag, profile: CheerioStatic): Pr
     return {
       age: undefined,
       reason: oneLine`
-        I could not find a reg date on the SA profile page for the username you provided. The bot
-        owner has been notified. Thank you for your patience while they get this fixed!
+        I could not find a reg date on your SA profile page. The bot owner has been notified. Thank
+        you for your patience while they get this fixed!
       `,
     };
   }

--- a/src/helpers/auth/getSAProfile.ts
+++ b/src/helpers/auth/getSAProfile.ts
@@ -17,10 +17,19 @@ const reasonErrorLoadingProfile = oneLine`
 /**
  * Grab the user's SA Profile page and wrap it in Cheerio
  */
-export default async function getSAProfile (tag: LogTag, username: string): Promise<SAProfile> {
-  logger.info(tag, 'Retrieving SA profile page');
-
-  const url = `${SA_URLS.PROFILE}${encodeURIComponent(username)}`;
+export default async function getSAProfile (
+  tag: LogTag,
+  username?: string,
+  userID?: string,
+): Promise<SAProfile> {
+  let url = SA_URLS.PROFILE;
+  if (username) {
+    logger.info(tag, `Retrieving SA profile page by username: "${username}"`);
+    url += `&username=${encodeURIComponent(username)}`;
+  } else if (userID) {
+    logger.info(tag, `Retrieving SA profile page by user ID: ${userID}`);
+    url += `&userid=${encodeURIComponent(userID)}`;
+  }
 
   try {
     // Request HTML

--- a/src/helpers/axiosSA.ts
+++ b/src/helpers/axiosSA.ts
@@ -20,5 +20,5 @@ export const axiosSA = axios.create({
 });
 
 export const SA_URLS = {
-  PROFILE: 'http://forums.somethingawful.com/member.php?action=getinfo&username=',
+  PROFILE: 'http://forums.somethingawful.com/member.php?action=getinfo',
 };

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -12,9 +12,8 @@ export const {
   PAPERTRAIL_PORT = -1,
   // Bot Config
   CMD_PREFIX = '!',
-  // Default to requiring the user to have registered at least 7 days ago (a deterrent to creating
-  // new SA accounts to bypass a blacklist)
-  MIN_ACCOUNT_AGE_DAYS = 7,
+  // Number of days old an account must be for auth
+  AUTH_MIN_ACCOUNT_AGE_DAYS = 7,
   // How long the bot can idle in an unenrolled server
   MAX_IDLE_DAYS = 3,
 } = process.env;

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -14,6 +14,8 @@ export const {
   CMD_PREFIX = '!',
   // Number of days old an account must be for auth
   AUTH_MIN_ACCOUNT_AGE_DAYS = 7,
+  // Number of days old an account must be for server enrollment
+  ENROLL_MIN_ACCOUNT_AGE_DAYS = 7,
   // How long the bot can idle in an unenrolled server
   MAX_IDLE_DAYS = 3,
 } = process.env;


### PR DESCRIPTION
This PR adds an account age check during server enrollment. The `!toggle-role` command is also disabled globally pending its extraction into a separate bot.