### PR TITLE
feature/remove-lowtax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /usr/src/app
 
 # Install dependencies
 COPY package*.json tsconfig.json ./
-RUN npm install
+RUN npm ci
 
 # Copy source files
 COPY src/ ./src/

--- a/src/commands/auth/authme.ts
+++ b/src/commands/auth/authme.ts
@@ -134,7 +134,7 @@ export default class AuthmeCommand extends GDNCommand {
         **${hash}**
 
         ${oneLine`
-          After you've completed this, return **here** and respond with **Praise Lowtax** to verify
+          After you've completed this, return **here** and respond with **done** to verify
           your SA membership.
         `}
       `);
@@ -170,7 +170,7 @@ export default class AuthmeCommand extends GDNCommand {
     cleanupMessages([hashMessage]);
 
     if (confirmation.cancelled) {
-      logger.warn(tag, 'User did not praise Lowtax, exiting');
+      logger.warn(tag, 'User did not confirm hash placement, exiting');
 
       return member.send(oneLine`
         You have not been authenticated. Please feel free to try again back in **${guild.name}**.

--- a/src/commands/auth/authme.ts
+++ b/src/commands/auth/authme.ts
@@ -18,7 +18,7 @@ import isMemberBlacklisted from '../../checks/isMemberBlacklisted';
 
 // Auth helpers
 import startAuthCheck from '../../helpers/auth/startAuthCheck';
-import praiseLowtaxCollector from '../../helpers/auth/praiseLowtaxCollector';
+import confirmHashPlacementCollector from '../../helpers/auth/confirmHashPlacementCollector';
 
 // Auth actions
 import getHash from '../../helpers/auth/getHash';
@@ -164,7 +164,7 @@ export default class AuthmeCommand extends GDNCommand {
      */
     logger.info(tag, 'Awaiting response from member');
 
-    const confirmation = await praiseLowtaxCollector((hashMessage.channel as DMChannel));
+    const confirmation = await confirmHashPlacementCollector((hashMessage.channel as DMChannel));
 
     // We're done with the hash, so remove it
     cleanupMessages([hashMessage]);

--- a/src/helpers/auth/confirmHash.ts
+++ b/src/helpers/auth/confirmHash.ts
@@ -11,7 +11,7 @@ interface ConfirmedHash {
 
 function reasonNotValidated (username: string): string {
   return oneLine`
-    Lowtax is disappointed in you. Enter **!authme ${username}** back in the server to try again
+    The hash could not be found. Enter **!authme ${username}** back in the server to try again
     :getout:
   `;
 }

--- a/src/helpers/auth/confirmHashPlacementCollector.ts
+++ b/src/helpers/auth/confirmHashPlacementCollector.ts
@@ -4,7 +4,7 @@ interface CollectorResults {
   cancelled: boolean;
 }
 
-const filter: CollectorFilter = text => text.content.toLowerCase() === 'praise lowtax';
+const filter: CollectorFilter = text => text.content.length > 0;
 const collectorOptions: AwaitMessagesOptions = {
   max: 1,
   maxProcessed: 3,
@@ -14,11 +14,10 @@ const collectorOptions: AwaitMessagesOptions = {
 };
 
 /**
- * A collector specifically for requesting the user to type 'praise lowtax' after
- * adding the auth hash to their SA profile. This should trigger the verification step of the
- * authme process.
+ * A collector specifically for requesting the user to confirm they've placed the auth hash in
+ * their SA profile. This should trigger the verification step of the authme process.
  */
-export default async function praiseLowtaxCollector (
+export default async function confirmHashPlacementCollector (
   channel: DMChannel,
 ): Promise<CollectorResults> {
   return channel.awaitMessages(filter, collectorOptions)

--- a/tests/authme.spec.ts
+++ b/tests/authme.spec.ts
@@ -432,37 +432,6 @@ test('logs message when an invalid log channel is specified for auth success mes
   expect(logger.info).toHaveBeenCalledWith({ req_id: message.id }, 'No text channel found by that ID');
 });
 
-test('messages user to try again when they fail to praise lowtax', async () => {
-  // Guild is enrolled in GDN
-  moxios.stubRequest(GDN_GUILD, {
-    status: 200,
-    response: {
-      validated_role_id: roleID,
-      logging_channel_id: channelID,
-    },
-  });
-
-  // Member has never authed before
-  moxios.stubRequest(GDN_MEMBER, {
-    status: 404,
-  });
-
-  // GoonAuth generates hash for user
-  moxios.stubRequest(GAUTH_GET, {
-    status: 200,
-    response: {
-      hash: 'abc',
-    },
-  });
-
-  // User responds with "done"
-  userDM.awaitMessages.mockRejectedValue([]);
-
-  await authme.run(message, { username: saUsername });
-
-  expect(member.send).toHaveBeenLastCalledWith(`You have not been authenticated. Please feel free to try again back in **${guild.name}**.`);
-});
-
 test('messages user when hash could not be confirmed in their profile', async () => {
   // Guild is enrolled in GDN
   moxios.stubRequest(GDN_GUILD, {

--- a/tests/authme.spec.ts
+++ b/tests/authme.spec.ts
@@ -220,8 +220,8 @@ test('[HAPPY PATH] adds role to user that has never authed before', async () => 
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -455,7 +455,7 @@ test('messages user to try again when they fail to praise lowtax', async () => {
     },
   });
 
-  // User responds with "praise lowtax"
+  // User responds with "done"
   userDM.awaitMessages.mockRejectedValue([]);
 
   await authme.run(message, { username: saUsername });
@@ -486,8 +486,8 @@ test('messages user when hash could not be confirmed in their profile', async ()
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -499,7 +499,7 @@ test('messages user when hash could not be confirmed in their profile', async ()
 
   await authme.run(message, { username: saUsername });
 
-  expect(member.send).toHaveBeenLastCalledWith(`Lowtax is disappointed in you. Enter **!authme ${saUsername}** back in the server to try again :getout:`);
+  expect(member.send).toHaveBeenLastCalledWith(`The hash could not be found. Enter **!authme ${saUsername}** back in the server to try again :getout:`);
 });
 
 test('messages user that an error occurred when an unexpected hash request response is returned', async () => {
@@ -550,8 +550,8 @@ test('messages user that an error occurred when an unexpected hash confirmation 
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -586,8 +586,8 @@ test('messages user and logs error when an SA ID could not be retrieved for thei
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -632,8 +632,8 @@ test('messages channel that member is blacklisted when their SA ID is linked to 
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -706,8 +706,8 @@ test('messages channel when user post count is too low', async () => {
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -751,8 +751,8 @@ test('messages user and logs error when an error occurs while retrieving SA prof
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -796,8 +796,8 @@ test('messages user when bot is unable to parse post count from profile', async 
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -842,8 +842,8 @@ test('logs error when error occurs while adding user to database', async () => {
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -897,8 +897,8 @@ test('logs error 50013 error occurs while assigning role to authed user', async 
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -959,8 +959,8 @@ test('reports misconfiguration in channel when 50013 error occurs while assignin
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {
@@ -1024,8 +1024,8 @@ test('logs error when 50013 error occurs while assigning role to authed user but
     },
   });
 
-  // User responds with "praise lowtax"
-  userDM.awaitMessages.mockResolvedValue([]);
+  // User responds with "done"
+  userDM.awaitMessages.mockResolvedValue(['done']);
 
   // GoonAuth is able to find hash in SA profile
   moxios.stubRequest(GAUTH_CONFIRM, {


### PR DESCRIPTION
Users are no longer required to praise Lowtax while authing with GDN.