### PR TITLE
Specify expected responses when enrolling

### DIFF
--- a/src/commands/gdn/enrollServer.ts
+++ b/src/commands/gdn/enrollServer.ts
@@ -151,7 +151,7 @@ export default class ListCommand extends GDNCommand {
       {
         key: 'confirm',
         prompt: stripIndents`
-          does everything look correct?
+          does everything look correct? Respond with **yes** or **no** to continue:
 
           **Server Name:** ${details.name}
           **Description:** ${details.description}


### PR DESCRIPTION
This PR makes expected responses more explicit to help guild admins more smoothly enroll their server into GDN. This should solve Issue #17.