### PR TITLE
feat/server-deactivation

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -17,6 +17,7 @@ import updateServerCountActivity from './tasks/updateServerCountActivity';
 import {
   updateHomepageMemberCounts,
 } from './tasks/updateHomepageMemberCounts';
+import reactivateGuildInGDN from './tasks/reactivateGuildInGDN';
 import deactivateGuildInGDN from './tasks/deactivateGuildInGDN';
 import syncSAPermabans from './tasks/syncSAPermabans';
 import leaveIdleServers from './tasks/leaveIdleServers';
@@ -105,6 +106,9 @@ bot.on('guildCreate', (guild: Guild) => {
 
   logger.info(tag, `Joined guild ${guild.name} (${guild.id})`);
   updateServerCountActivity(tag, bot);
+
+  // Try to re-enable the guild if it's been deactivated
+  reactivateGuildInGDN(tag, guild);
 });
 
 // When the bot leaves a Guild
@@ -114,8 +118,8 @@ bot.on('guildDelete', (guild: Guild) => {
   logger.info(tag, `Left guild ${guild.name} (${guild.id})`);
 
   updateServerCountActivity(tag, bot);
-  // Temporarily disable this since Discord is doing some kind of netsplit that's
-  // errantly causing this bot to delete servers from GDN
+
+  // Mark this server as "deactivated" so it's hidden on the GDN homepage
   deactivateGuildInGDN(tag, guild);
 });
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -17,7 +17,7 @@ import updateServerCountActivity from './tasks/updateServerCountActivity';
 import {
   updateHomepageMemberCounts,
 } from './tasks/updateHomepageMemberCounts';
-// import removeGuildFromGDN from './tasks/removeGuildFromGDN';
+import deactivateGuildInGDN from './tasks/deactivateGuildInGDN';
 import syncSAPermabans from './tasks/syncSAPermabans';
 import leaveIdleServers from './tasks/leaveIdleServers';
 
@@ -116,7 +116,7 @@ bot.on('guildDelete', (guild: Guild) => {
   updateServerCountActivity(tag, bot);
   // Temporarily disable this since Discord is doing some kind of netsplit that's
   // errantly causing this bot to delete servers from GDN
-  // removeGuildFromGDN(tag, guild);
+  deactivateGuildInGDN(tag, guild);
 });
 
 // When a Member joins a Guild

--- a/src/tasks/deactivateGuildInGDN.ts
+++ b/src/tasks/deactivateGuildInGDN.ts
@@ -5,17 +5,20 @@ import logger, { LogTag } from '../helpers/logger';
 import { axiosGDN, GDN_URLS } from '../helpers/axiosGDN';
 
 /**
- * Remove a Discord Guild from GDN
+ * Soft-delete a Discord Guild in GDN
  */
-export default function removeGuildFromGDN (tag: LogTag, guild: Guild) {
+export default function deactivateGuildInGDN (tag: LogTag, guild: Guild) {
   return axiosGDN.delete(`${GDN_URLS.GUILDS}/${guild.id}`)
     .then(() => {
-      logger.info(tag, `Deleted guild ${guild.name} (${guild.id}) from GDN`);
+      logger.info(tag, `Deactivated guild ${guild.name} (${guild.id}) in GDN`);
     })
     .catch((err: AxiosError) => {
       // 404 means we tried to delete a server not enrolled in GDN
       if (err.response?.status !== 404) {
-        logger.error({ ...tag, err }, `Error deleting guild ${guild.name} (${guild.id}) from GDN`);
+        logger.error(
+          { ...tag, err },
+          `Error deactivating guild ${guild.name} (${guild.id}) in GDN`,
+        );
       }
     });
 }

--- a/src/tasks/reactivateGuildInGDN.ts
+++ b/src/tasks/reactivateGuildInGDN.ts
@@ -1,0 +1,24 @@
+import { Guild } from 'discord.js';
+import { AxiosError } from 'axios';
+
+import logger, { LogTag } from '../helpers/logger';
+import { axiosGDN, GDN_URLS } from '../helpers/axiosGDN';
+
+/**
+ * Reset a Discord Guild's deactivated status in GDN
+ */
+export default function reactivateGuildInGDN (tag: LogTag, guild: Guild) {
+  return axiosGDN.patch(`${GDN_URLS.GUILDS}/${guild.id}`, { deactivated: false })
+    .then(() => {
+      logger.info(tag, `Reactivated guild ${guild.name} (${guild.id}) in GDN`);
+    })
+    .catch((err: AxiosError) => {
+      // 404 means we tried to reactivate a server that was never enrolled in GDN
+      if (err.response?.status !== 404) {
+        logger.error(
+          { ...tag, err },
+          `Error reactivating guild ${guild.name} (${guild.id}) in GDN`,
+        );
+      }
+    });
+}


### PR DESCRIPTION
This PR adds the ability for GDNbot to mark a server as "deactivated" when it leaves a Discord Guild, then reactivate it if the bot rejoins the server later on.